### PR TITLE
check curl result for return value 'false'

### DIFF
--- a/Curl/CurlMulti.php
+++ b/Curl/CurlMulti.php
@@ -353,10 +353,10 @@ class CurlMulti extends AbstractHasDispatcher implements CurlMultiInterface
      */
     private function checkCurlResult($code)
     {
-        if ($code != CURLM_OK && $code != CURLM_CALL_MULTI_PERFORM) {
+        if ($code !== CURLM_OK && $code !== CURLM_CALL_MULTI_PERFORM) {
             throw new CurlException(isset($this->multiErrors[$code])
                 ? "cURL error: {$code} ({$this->multiErrors[$code][0]}): cURL message: {$this->multiErrors[$code][1]}"
-                : 'Unexpected cURL error: ' . $code
+                : 'Unexpected cURL error: ' . ($code === false ? 'false' : $code)
             );
         }
     }


### PR DESCRIPTION
If curl_multi_exec returns false (probably because curl handle has already been closed with curl_multi_close) the method checkCurlResult did not throw an exception. I modified comparision of $code to type-strict to also throw an exception when $code === false.
