### PR TITLE
Fix clone function for EntityEnclosingRequest

### DIFF
--- a/Message/EntityEnclosingRequest.php
+++ b/Message/EntityEnclosingRequest.php
@@ -43,6 +43,13 @@ class EntityEnclosingRequest extends Request implements EntityEnclosingRequestIn
 
         return parent::__toString() . $this->body;
     }
+    
+    public function __clone()
+    {
+        $this->postFields = clone ($this->postFields);
+        
+        parent::__clone();
+    }
 
     public function setState($state, array $context = array())
     {


### PR DESCRIPTION
The field "postFields" added only in this class, but this property not cloned.

If we not clone this property, we have a reference error.
